### PR TITLE
Add basic web UI for building repositories

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,6 +44,16 @@ A CLI tool to simplify the process of cloning, building, and containerizing appl
 ./mycliapp https://github.com/user/sample-app.git
 ```
 
+### Web UI
+
+A minimal web interface is also available for triggering builds from a browser.
+
+```bash
+go run cmd/web/main.go
+```
+
+Open `http://localhost:8080` and submit the repository URL, image name and tag to start the build process.
+
 ## Technical Details
 
 - **Modular Architecture**: The application is designed using Object-Oriented Principles in Go, with distinct modules for displaying content (`Display`), managing repositories (`RepoManager`), and building & tagging container images (`ImageBuilder`).

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"cliapp/internal/utils"
+	"cliapp/pkg/imagebuilder"
+)
+
+func main() {
+	http.HandleFunc("/", indexHandler)
+	http.HandleFunc("/build", buildHandler)
+
+	log.Println("Starting web UI on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, `<!DOCTYPE html>
+<html>
+<head><title>Builder CI</title></head>
+<body>
+<h1>Builder CI</h1>
+<form action="/build" method="post">
+<label>Repository URL:</label><br>
+<input type="text" name="repoURL" required><br><br>
+<label>Image Name:</label><br>
+<input type="text" name="imageName" required><br><br>
+<label>Image Tag:</label><br>
+<input type="text" name="imageTag" required><br><br>
+<input type="submit" value="Start Build">
+</form>
+</body>
+</html>`)
+}
+
+func buildHandler(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "failed to parse form: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	repoURL := r.FormValue("repoURL")
+	imageName := r.FormValue("imageName")
+	imageTag := r.FormValue("imageTag")
+
+	if repoURL == "" || imageName == "" || imageTag == "" {
+		http.Error(w, "repoURL, imageName and imageTag are required", http.StatusBadRequest)
+		return
+	}
+
+	if err := utils.Clone(repoURL); err != nil {
+		http.Error(w, "error cloning repository: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	repoName := utils.GetRepoNameFromURL(repoURL)
+	language, _ := utils.DetectLanguage(repoName)
+	imgBuilder := imagebuilder.NewImageBuilderImpl(language)
+	if imgBuilder.SelectBuilder() == "" {
+		http.Error(w, "unsupported language: "+language, http.StatusBadRequest)
+		return
+	}
+
+	if err := imgBuilder.Build(imageName); err != nil {
+		http.Error(w, "build failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := imgBuilder.TagImage(imageName, imageTag); err != nil {
+		http.Error(w, "tagging failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprintf(w, "Build and tagging complete! Image: %s:%s", imageName, imageTag)
+}


### PR DESCRIPTION
## Summary
- serve a minimal HTTP interface to clone repos and build/tag images
- document how to run the new UI

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890b3e7b99883249e93138298c7c338