### PR TITLE
Add Helm chart and Argo-based pipeline

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -115,3 +115,26 @@ A CLI tool to simplify the process of cloning, building, and containerizing appl
 5. Open a pull request.
 
 ---
+
+## Kubernetes Deployment
+
+A Helm chart is available in `charts/cliapp` for running the CLI inside a Kubernetes cluster using a `Job`. This makes installation and execution consistent across environments.
+
+```bash
+# Install the chart
+helm install mycli charts/cliapp --set image.repository=<your-repo> --set image.tag=<tag>
+```
+
+## Kubernetes-based CI Pipeline
+
+The `ci/` directory contains an example [Argo Workflow](https://argoproj.github.io/) that runs CI stages in separate namespaces, each as its own pod.
+
+```bash
+# Create isolated namespaces for each stage
+kubectl apply -f ci/namespaces.yaml
+
+# Submit the workflow (assuming Argo is installed in the cluster)
+kubectl create -f ci/argo-workflow.yaml -n argo
+```
+
+Each pipeline stage is executed as an individual Kubernetes `Job`, enabling fine-grained isolation and leveraging native primitives for orchestration.

--- a/charts/cliapp/Chart.yaml
+++ b/charts/cliapp/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: cliapp
+version: 0.1.0
+appVersion: "0.1.0"
+description: Helm chart for running MyCLIApp as a Kubernetes Job
+home: https://example.com/cliapp
+

--- a/charts/cliapp/templates/_helpers.tpl
+++ b/charts/cliapp/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "cliapp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "cliapp.fullname" -}}
+{{- printf "%s-%s" .Release.Name (include "cliapp.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/cliapp/templates/job.yaml
+++ b/charts/cliapp/templates/job.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "cliapp.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "cliapp.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: cliapp
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: {{ toYaml .Values.command | nindent 12 }}
+          args: {{ toYaml .Values.args | nindent 12 }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/charts/cliapp/values.yaml
+++ b/charts/cliapp/values.yaml
@@ -1,0 +1,11 @@
+image:
+  repository: myregistry/mycliapp
+  tag: latest
+  pullPolicy: IfNotPresent
+
+command:
+  - "./mycliapp"
+args: []
+
+resources: {}
+

--- a/ci/argo-workflow.yaml
+++ b/ci/argo-workflow.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: buildercli-pipeline
+spec:
+  entrypoint: pipeline
+  templates:
+  - name: pipeline
+    steps:
+    - - name: build
+        template: run-job
+        arguments:
+          parameters:
+          - name: ns
+            value: build-stage
+    - - name: test
+        template: run-job
+        arguments:
+          parameters:
+          - name: ns
+            value: test-stage
+    - - name: push
+        template: run-job
+        arguments:
+          parameters:
+          - name: ns
+            value: push-stage
+  - name: run-job
+    inputs:
+      parameters:
+      - name: ns
+    resource:
+      action: apply
+      manifest: |
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          generateName: {{inputs.parameters.ns}}-
+          namespace: {{inputs.parameters.ns}}
+        spec:
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+              - name: stage
+                image: alpine
+                command: ["sh","-c","echo running in {{inputs.parameters.ns}}"]
+

--- a/ci/namespaces.yaml
+++ b/ci/namespaces.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: build-stage
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-stage
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: push-stage


### PR DESCRIPTION
## Summary
- add Helm chart to run the CLI as a Kubernetes Job
- provide Argo Workflow pipeline using separate namespaces for each stage
- document Helm deployment and Argo pipeline usage in the README

## Testing
- `go test ./...`
- attempted `apt-get update` and direct download for Helm but both failed with HTTP 403, so linting could not be run

------
https://chatgpt.com/codex/tasks/task_e_6890b742f0c483249b158fdd6d60cea1